### PR TITLE
Exposed getDataLayoutInnerSize() function

### DIFF
--- a/include/qdp_datalayout.h
+++ b/include/qdp_datalayout.h
@@ -8,6 +8,8 @@ namespace QDP {
 
   void QDP_set_jit_datalayout(int pos_o, int pos_s, int pos_c, int pos_r, int pos_i);
   void QDP_print_jit_datalayout();
+  bool QDP_assert_jit_datalayout(int pos_o, int pos_s, int pos_c, int pos_r, int pos_i);
+  int64_t getDataLayoutInnerSize();
   //llvm::Value * datalayout_stack(IndexDomainVector a);
 
 } // namespace QDP

--- a/include/qdp_multi.h
+++ b/include/qdp_multi.h
@@ -24,6 +24,8 @@ namespace QDP {
 template<class T> class multi1d
 {
 public:
+  typedef T InnerType_t;
+
   // Basic cosntructor. Null (0x0) array_pointer, no copymem, no fast memory
   multi1d() {F=0;n1=0;copymem=false;fast_mem_hint=false;}
 

--- a/lib/qdp_datalayout.cc
+++ b/lib/qdp_datalayout.cc
@@ -84,6 +84,16 @@ namespace QDP {
     QDP_jit_layout[pos_i] = 4;
   }
 
+  bool QDP_assert_jit_datalayout(int pos_o, int pos_s, int pos_c, int pos_r, int pos_i) {
+	  bool correct = ( QDP_jit_layout[pos_o] == 0)
+					  && (QDP_jit_layout[pos_s] == 1)
+					  && (QDP_jit_layout[pos_c] == 2)
+					  && (QDP_jit_layout[pos_r] == 3)
+					  && (QDP_jit_layout[pos_i] == 4);
+
+	  return correct;
+  }
+
   void QDP_print_jit_datalayout() {
     const char* letters="oscri";
     QDPIO::cerr << "Using JIT data layout ";

--- a/lib/qdp_parscalar_init.cc
+++ b/lib/qdp_parscalar_init.cc
@@ -450,7 +450,7 @@ namespace QDP {
 	  if (QMP_is_initialized() == QMP_FALSE)
 	    {
 	      QMP_thread_level_t prv;
-	      if (QMP_init_msg_passing(argc, argv, QMP_THREAD_SINGLE, &prv) != QMP_SUCCESS)
+	      if (QMP_init_msg_passing(argc, argv, QMP_THREAD_MULTIPLE, &prv) != QMP_SUCCESS)
 		{
 		  QDPIO::cerr << __func__ << ": QMP_init_msg_passing failed" << endl;
 		  QDP_abort(1);


### PR DESCRIPTION
Hi Frank, 
 Here is my attempt to make a pull request. I've:
   - exposed getDataLayoutInnerSize()
  - added a QDP_assert_jit_datalayout() function
  - added and InnerType_t to multi1d<T> so I can use WordType<BlahBlah::InnerType_t>::Type_t
    to get the base precision of a multi1d<T>

I think my changes are a fast forward of yours, so you can even automatically merge in these changes if you approve.