### PR TITLE
Tbballoc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -440,6 +440,25 @@ then
 	AC_DEFINE([QDP_USE_OMP_THREADS], [1], [ Use OpenMP Threads ])
 fi
 
+
+AC_ARG_ENABLE(tbb-pool-allocator,
+	AC_HELP_STRING([--enable-tbb-pool-allocator],
+		[ Enable Threaded Building Blocks Fixed Pool Allocator]),
+	[ ac_enable_tbbpool=${enableval} ],
+	[ ac_enable_tbbpool="no" ]
+)
+
+dnl Threaded Building Blocks Pool Allocator
+if test "X${ac_enable_tbbpool}X" == "XyesX";
+then 
+	AC_MSG_NOTICE([Configuring to use TBB Fixed Pool. Please ensure CXXFLAGS and LDFLAGS are correctly set])
+	AC_DEFINE([QDP_USE_TBBPOOL_ALLOCATOR],[1], [ Use TBB Fixed Pool Allocator ])
+else
+	AC_MSG_NOTICE([Not Configuring Pool Allocator])
+fi
+
+AM_CONDITIONAL(BUILD_QDPJIT_TBB_ALLOCATOR, [test "X${ac_enable_tbbpool}X" == "XyesX" ])
+  
 dnl
 dnl
 dnl Now have all the options... Do some configuration 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,7 +13,8 @@ PETE_HDRS =  PETE/Combiners.h \
 MEMORY_HDRS = qdp_allocator.h \
 	      qdp_singleton.h \
 	      qdp_default_allocator.h \
-	      qdp_qcdoc_allocator.h
+	      qdp_qcdoc_allocator.h \
+	      qdp_pool_allocator.h
 
 JIT_HDRS = qdp_mapresource.h \
 	    qdp_llvm.h qdp_viewleaf.h \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,8 +13,11 @@ PETE_HDRS =  PETE/Combiners.h \
 MEMORY_HDRS = qdp_allocator.h \
 	      qdp_singleton.h \
 	      qdp_default_allocator.h \
-	      qdp_qcdoc_allocator.h \
-	      qdp_pool_allocator.h
+	      qdp_qcdoc_allocator.h
+
+if BUILD_QDPJIT_TBB_ALLOCATOR
+MEMORY_HDRS += qdp_pool_allocator.h
+endif
 
 JIT_HDRS = qdp_mapresource.h \
 	    qdp_llvm.h qdp_viewleaf.h \

--- a/include/qdp_default_allocator.h
+++ b/include/qdp_default_allocator.h
@@ -9,8 +9,8 @@
 #define QDP_DEFAULT_ALLOCATOR
 
 #include "qdp_allocator.h"
-//#include "qdp_stdio.h"
-#include "qdp_singleton.h"
+#include "qdp_stdio.h"
+
 #include <string>
 #include <map>
 
@@ -32,11 +32,13 @@ namespace QDP
       // the singleton CreateUsingNew policy which is a "friend"
       // I don't like friends but this follows Alexandrescu's advice
       // on p154 of Modern C++ Design (A. Alexandrescu)
-      QDPDefaultAllocator() {init();}
+      QDPDefaultAllocator() {}
       ~QDPDefaultAllocator() {}
 
       friend class QDP::CreateUsingNew<QDP::Allocator::QDPDefaultAllocator>;
     public:
+
+      void init(size_t PoolSizeinMB);
 
       // Pusher
       void pushFunc(const char* func, int line);
@@ -58,22 +60,10 @@ namespace QDP
       void
       dump();
 
-    protected:
-      void init();
+
+
     };
 
-    // Turn into a Singleton. Create with CreateUsingNew
-    // Has NoDestroy lifetime, as it may be needed for 
-    // the destruction policy is No Destroy, so the 
-    // Singleton is not cleaned up on exit. This is so 
-    // that static objects can refer to it with confidence
-    // in their own destruction, not having to worry that
-    // atexit() may have destroyed the allocator before
-    // the static objects need to feed memory. 
-    typedef SingletonHolder<QDP::Allocator::QDPDefaultAllocator,
-			    QDP::CreateUsingNew,
-			    QDP::NoDestroy,
-			    QDP::SingleThreaded> theQDPAllocator;
 
   } // namespace Allocator
 } // namespace QDP

--- a/include/qdp_outer.h
+++ b/include/qdp_outer.h
@@ -4,7 +4,7 @@
 #define QDP_OUTER_H
 
 #include "qdp_config.h"
-
+#include "qdp_pool_allocator.h"
 /*! \file
  * \brief Outer grid classes
  */
@@ -435,35 +435,55 @@ void evaluate(OScalar<T>& dest, const Op& op, const QDPExpr<RHS,OScalar<T1> >& r
 
 
     inline void alloc_mem(MemoryUsage where, const char* msg) const {
-      if (where == MemoryUsageJIT)
-	assert( !F_alloc[1] && "alloc_mem already allocated (jit)");
-      else
-	assert( !F_alloc[0] && "alloc_mem already allocated (native)");
+    	if (where == MemoryUsageJIT)
+    		assert( !F_alloc[1] && "alloc_mem already allocated (jit)");
+    	else
+    		assert( !F_alloc[0] && "alloc_mem already allocated (native)");
 
-      T* tmp;
-      try {
-	 tmp = (T*)QDP::Allocator::theQDPAllocator::Instance().allocate( sizeof(T) * Layout::sitesOnNode() ,
-									 QDP::Allocator::DEFAULT ); }
-      catch(std::bad_alloc) {
-	QDPIO::cerr << "Allocation failed in OLattice alloc_mem" << endl;
-	QDP::Allocator::theQDPAllocator::Instance().dump();
-	QDP_abort(1);
-      }
-      if (where == MemoryUsageJIT) {
-	F_jit = tmp;
-	F_alloc[1] = true;
-      } else {
-	F = tmp;
-	F_alloc[0] = true;
-      }
+    	T* tmp;
+
+    	try {
+#if 0
+    		tmp = (T*)QDP::Allocator::theQDPAllocator::Instance().allocate( sizeof(T) * Layout::sitesOnNode() ,
+    				QDP::Allocator::DEFAULT );
+#else
+    		tmp = (T*)QDP::Allocator::theQDPPoolAllocator::Instance().alloc( sizeof(T) * Layout::sitesOnNode() );
+#endif
+
+    	}
+    	catch(std::bad_alloc) {
+    		QDPIO::cerr << "Allocation failed in OLattice alloc_mem" << endl;
+#if 0
+    		QDP::Allocator::theQDPAllocator::Instance().dump();
+#endif
+    		QDP_abort(1);
+    	}
+    	if (where == MemoryUsageJIT) {
+    		F_jit = tmp;
+    		F_alloc[1] = true;
+    	} else {
+    		F = tmp;
+    		F_alloc[0] = true;
+    	}
 
     }
 
     inline void free_mem() {
-      if (F_alloc[1])
-	QDP::Allocator::theQDPAllocator::Instance().free( F_jit );
-      if (F_alloc[0])
-	QDP::Allocator::theQDPAllocator::Instance().free( F );
+    	if (F_alloc[1]) {
+#if 0
+    		QDP::Allocator::theQDPAllocator::Instance().free( F_jit );
+#else
+    		QDP::Allocator::theQDPPoolAllocator::Instance().free( F_jit );
+#endif
+
+    	}
+    	if (F_alloc[0]) {
+#if 0
+    		QDP::Allocator::theQDPAllocator::Instance().free( F );
+#else
+    		QDP::Allocator::theQDPPoolAllocator::Instance().free( F );
+#endif
+    	}
     }
 
 

--- a/include/qdp_outer.h
+++ b/include/qdp_outer.h
@@ -4,7 +4,7 @@
 #define QDP_OUTER_H
 
 #include "qdp_config.h"
-#include "qdp_pool_allocator.h"
+#include "qdp_allocator.h"
 /*! \file
  * \brief Outer grid classes
  */
@@ -443,19 +443,13 @@ void evaluate(OScalar<T>& dest, const Op& op, const QDPExpr<RHS,OScalar<T1> >& r
     	T* tmp;
 
     	try {
-#if 0
     		tmp = (T*)QDP::Allocator::theQDPAllocator::Instance().allocate( sizeof(T) * Layout::sitesOnNode() ,
     				QDP::Allocator::DEFAULT );
-#else
-    		tmp = (T*)QDP::Allocator::theQDPPoolAllocator::Instance().alloc( sizeof(T) * Layout::sitesOnNode() );
-#endif
 
     	}
     	catch(std::bad_alloc) {
     		QDPIO::cerr << "Allocation failed in OLattice alloc_mem" << endl;
-#if 0
     		QDP::Allocator::theQDPAllocator::Instance().dump();
-#endif
     		QDP_abort(1);
     	}
     	if (where == MemoryUsageJIT) {
@@ -470,19 +464,12 @@ void evaluate(OScalar<T>& dest, const Op& op, const QDPExpr<RHS,OScalar<T1> >& r
 
     inline void free_mem() {
     	if (F_alloc[1]) {
-#if 0
+
     		QDP::Allocator::theQDPAllocator::Instance().free( F_jit );
-#else
-    		QDP::Allocator::theQDPPoolAllocator::Instance().free( F_jit );
-#endif
 
     	}
     	if (F_alloc[0]) {
-#if 0
     		QDP::Allocator::theQDPAllocator::Instance().free( F );
-#else
-    		QDP::Allocator::theQDPPoolAllocator::Instance().free( F );
-#endif
     	}
     }
 

--- a/include/qdp_pool_allocator.h
+++ b/include/qdp_pool_allocator.h
@@ -28,15 +28,31 @@ namespace QDP
 
  	 // Quick and Dirty Pool ALlocator
  	 class QDPPoolAllocator {
- 	 public:
+ 	 private:
+ 		 // Disallow Copies
+ 		 QDPPoolAllocator(const QDPPoolAllocator& c) {}
+
+ 		 // Disallow assignments (copies by another name)
+ 		 void operator=(const QDPPoolAllocator& c) {}
+
+ 		 // Disallow creation / destruction by anyone except
+ 		 // 	the singleton CreateUsingNew policy which is a "friend"
+ 		 // I don't like friends but this follows Alexandrescu's advice
+ 		 // on p154 of Modern C++ Design (A. Alexandrescu)
  		 QDPPoolAllocator(void);
-
  		 ~QDPPoolAllocator();
+ 		 friend class QDP::CreateUsingNew<QDP::Allocator::QDPPoolAllocator>;
+ 	 public:
+ 		 // Init -- has to
+ 		 void  init(size_t PoolSizeInMB);
 
- 		 void  init(size_t PoolSizeInGB);
-
- 		 void* alloc(size_t size);
+ 		 void* allocate(size_t n_bytes, const MemoryPoolHint& mem_pool_hint);
  		 void  free(void *mem);
+
+ 		 // Memory debugging Interface
+ 		 void pushFunc(const char *func, int line);
+ 		 void popFunc(void);
+ 		 void dump();
 
 
  	 private:
@@ -48,18 +64,6 @@ namespace QDP
 
 
 
-    // Turn into a Singleton. Create with CreateUsingNew
-    // Has NoDestroy lifetime, as it may be needed for 
-    // the destruction policy is No Destroy, so the 
-    // Singleton is not cleaned up on exit. This is so 
-    // that static objects can refer to it with confidence
-    // in their own destruction, not having to worry that
-    // atexit() may have destroyed the allocator before
-    // the static objects need to feed memory. 
-    typedef SingletonHolder<QDP::Allocator::QDPPoolAllocator,
-			    QDP::CreateUsingNew,
-			    QDP::NoDestroy,
-			    QDP::SingleThreaded> theQDPPoolAllocator;
 
   } // namespace Allocator
 } // namespace QDP

--- a/include/qdp_pool_allocator.h
+++ b/include/qdp_pool_allocator.h
@@ -1,0 +1,67 @@
+// -*- C++ -*-
+
+/*! \file
+ * \brief Default memory allocator for QDP
+ *
+ */
+
+#ifndef QDP_POOL_ALLOCATOR
+#define QDP_POOL_ALLOCATOR
+
+
+#define TBB_PREVIEW_MEMORY_POOL 1
+#include "tbb/memory_pool.h"
+
+#include "qdp_singleton.h"
+namespace QDP
+{
+ 	 namespace Allocator {
+
+ 	 // A Descrptor contains the start block and the number of blocks
+ 	 // In an object
+ 	 // The idea is that when we allocate n_blocks, they will be contiguous
+ 	 // so we can just note the start, and the number
+ 	 // and then pop them off the end of the free list.
+ 	 // When we return to the pool we can just add back the blocks.
+
+
+
+ 	 // Quick and Dirty Pool ALlocator
+ 	 class QDPPoolAllocator {
+ 	 public:
+ 		 QDPPoolAllocator(void);
+
+ 		 ~QDPPoolAllocator();
+
+ 		 void  init(size_t PoolSizeInGB);
+
+ 		 void* alloc(size_t size);
+ 		 void  free(void *mem);
+
+
+ 	 private:
+ 		 size_t _PoolSize;
+ 		 unsigned char* _MyMem;
+ 		 tbb::fixed_pool* _LargePool;
+
+ 	 };
+
+
+
+    // Turn into a Singleton. Create with CreateUsingNew
+    // Has NoDestroy lifetime, as it may be needed for 
+    // the destruction policy is No Destroy, so the 
+    // Singleton is not cleaned up on exit. This is so 
+    // that static objects can refer to it with confidence
+    // in their own destruction, not having to worry that
+    // atexit() may have destroyed the allocator before
+    // the static objects need to feed memory. 
+    typedef SingletonHolder<QDP::Allocator::QDPPoolAllocator,
+			    QDP::CreateUsingNew,
+			    QDP::NoDestroy,
+			    QDP::SingleThreaded> theQDPPoolAllocator;
+
+  } // namespace Allocator
+} // namespace QDP
+
+#endif

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -37,7 +37,7 @@ libqdp_a_SOURCES += qdp_parscalar_init.cc qdp_parscalar_layout.cc \
 	qdp_scalarsite_specific.cc
 
 
-libqdp_a_SOURCES += qdp_default_allocator.cc
+libqdp_a_SOURCES += qdp_default_allocator.cc qdp_pool_allocator.cc
 
 
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -37,7 +37,10 @@ libqdp_a_SOURCES += qdp_parscalar_init.cc qdp_parscalar_layout.cc \
 	qdp_scalarsite_specific.cc
 
 
-libqdp_a_SOURCES += qdp_default_allocator.cc qdp_pool_allocator.cc
+libqdp_a_SOURCES += qdp_default_allocator.cc
+if BUILD_QDPJIT_TBB_ALLOCATOR
+libqdp_a_SOURCES += qdp_pool_allocator.cc
+endif
 
 
 

--- a/lib/qdp_default_allocator.cc
+++ b/lib/qdp_default_allocator.cc
@@ -8,6 +8,7 @@
 #include <stack>
 #endif
 
+#include "qdp_default_allocator.h"
 
 namespace QDP {
 namespace Allocator {
@@ -40,7 +41,7 @@ namespace Allocator {
   // A stack to hold fun info
   std::stack<FuncInfo_t> infostack;
 #else
-  typedef map<unsigned char*, unsigned char *> MapT;
+  typedef std::map<unsigned char*, unsigned char *> MapT;
 
 #endif
 
@@ -51,7 +52,7 @@ namespace Allocator {
 
   // The type returned on map insertion, allows me to check
   // the insertion was successful.
-  typedef pair<MapT::iterator, bool> InsertRetVal;
+  typedef std::pair<MapT::iterator, bool> InsertRetVal;
 
 
   //! Allocator function. Allocates n_bytes, into a memory pool
@@ -78,7 +79,7 @@ namespace Allocator {
       unaligned = new unsigned char[ bytes_to_alloc ];
     }
     catch( std::bad_alloc ) { 
-      QDPIO::cerr << "Unable to allocate memory in allocate()" << endl;
+      QDPIO::cerr << "Unable to allocate memory in allocate()" << std::endl;
       throw;  // Re throw the bad alloc is the correct behaviour
 
     }
@@ -95,12 +96,12 @@ namespace Allocator {
       make_pair(aligned, MapVal(unaligned, info.func, info.line, bytes_to_alloc)));
 #else
     // Insert into the map
-    InsertRetVal r = the_alignment_map.insert(make_pair(aligned, unaligned));
+    InsertRetVal r = the_alignment_map.insert(std::make_pair(aligned, unaligned));
 #endif
 
     // Check success of insertion.
     if( ! r.second ) { 
-      QDPIO::cerr << "Failed to insert (unaligned,aligned) pair into map" << endl;
+      QDPIO::cerr << "Failed to insert (unaligned,aligned) pair into map" << std::endl;
       QDP_abort(1);
     }
 
@@ -133,7 +134,7 @@ namespace Allocator {
       delete [] unaligned;
     }
     else { 
-      QDPIO::cerr << "Pointer not found in map" << endl;
+      QDPIO::cerr << "Pointer not found in map" << std::endl;
       QDP_abort(1);
     }
   }
@@ -148,7 +149,7 @@ namespace Allocator {
      {
        size_t sum = 0;
        typedef MapT::const_iterator CI;
-       QDPIO::cout << "Dumping memory map" << endl;
+       QDPIO::cout << "Dumping memory map" << std::endl;
        for( CI j = the_alignment_map.begin();
              j != the_alignment_map.end(); j++)
        {
@@ -173,7 +174,7 @@ namespace Allocator {
   {
     if (infostack.empty())
     {
-      QDPIO::cerr << __func__ << ": invalid pop" << endl;
+      QDPIO::cerr << __func__ << ": invalid pop" << std::endl;
       QDP_abort(1);
     }
   
@@ -199,7 +200,7 @@ namespace Allocator {
      if ( Layout::primaryNode() )
      {
        typedef MapT::const_iterator CI;
-       QDPIO::cout << "Dumping memory map" << endl;
+       QDPIO::cout << "Dumping memory map" << std::endl;
        for( CI j = the_alignment_map.begin();
              j != the_alignment_map.end(); j++)
        {
@@ -219,7 +220,10 @@ namespace Allocator {
 
   // Init
   void
-  QDPDefaultAllocator::init() {}
+  QDPDefaultAllocator::init(size_t PoolSizeInMB ) {
+	  QDPIO::cout << "Initializing QDPDefaultAllocator." << std::endl;
+
+  }
 
 #endif
 

--- a/lib/qdp_parscalar_init.cc
+++ b/lib/qdp_parscalar_init.cc
@@ -31,6 +31,7 @@ namespace QDP {
   multi1d<int> logical_geom(Nd);   // apriori logical geometry of the machine
   multi1d<int> logical_iogeom(Nd); // apriori logical 	
 
+  extern size_t pool_size_in_gb;
 
 #if 1
   int gamma_degrand_rossi[5][4][4][2] = 
@@ -355,6 +356,11 @@ namespace QDP {
 			  char tmp[1024];
 			  sscanf((*argv)[++i], "%s", &tmp);
 			  llvm_append_mattr(tmp);
+			}
+			else if ( strcmp((*argv)[i],"-poolsize")==0)
+			{
+				sscanf((*argv)[++i], "%d", &pool_size_in_gb);
+
 			}
 			else if (strcmp((*argv)[i], "-debug")==0) 
 			{

--- a/lib/qdp_parscalar_init.cc
+++ b/lib/qdp_parscalar_init.cc
@@ -31,7 +31,7 @@ namespace QDP {
   multi1d<int> logical_geom(Nd);   // apriori logical geometry of the machine
   multi1d<int> logical_iogeom(Nd); // apriori logical 	
 
-  extern size_t pool_size_in_gb;
+  extern float pool_size_in_gb;
 
 #if 1
   int gamma_degrand_rossi[5][4][4][2] = 
@@ -307,7 +307,10 @@ namespace QDP {
 				fprintf(stderr,"    -rtinode  %%s [%s] run-time interface fileserver node\n", 
 						rtinode);
 #endif
-				
+				fprintf(stderr, "   -poolsize <X>  Create a fixed pool of X GB for Pool Alloc\n");
+				fprintf(stderr, "   -threads <N>  run with N threads, specify binding manually\n");
+				fprintf(stderr, "   -layout ocsri/oscri or combinations -- Order of indices in layout\n");
+				fprintf(stderr, "   -inner  length of inntermost dimension, for vectorization ");
 				QDP_abort(1);
 			}
 		}
@@ -359,7 +362,7 @@ namespace QDP {
 			}
 			else if ( strcmp((*argv)[i],"-poolsize")==0)
 			{
-				sscanf((*argv)[++i], "%d", &pool_size_in_gb);
+				sscanf((*argv)[++i], "%f", &pool_size_in_gb);
 
 			}
 			else if (strcmp((*argv)[i], "-debug")==0) 

--- a/lib/qdp_parscalar_layout.cc
+++ b/lib/qdp_parscalar_layout.cc
@@ -15,7 +15,7 @@
 
 #include "qdp.h"
 #include "qdp_util.h"
-#include "qdp_pool_allocator.h"
+#include "qdp_allocator.h"
 #include "qmp.h"
 
 
@@ -33,7 +33,7 @@ namespace QDP
     return s;
   }
 
-  size_t pool_size_in_gb = 8;
+  float pool_size_in_gb = 8.0;
 
 //-----------------------------------------------------------------------------
   namespace Layout
@@ -365,7 +365,10 @@ namespace QDP
       }
 #endif
 
-      Allocator::theQDPPoolAllocator::Instance().init(pool_size_in_gb);
+
+      size_t pool_size_in_MB = static_cast<size_t>(floor(pool_size_in_gb*1024.0));
+
+      Allocator::theQDPAllocator::Instance().init(pool_size_in_MB);
 
       // Initialize various defaults
       initDefaults();

--- a/lib/qdp_parscalar_layout.cc
+++ b/lib/qdp_parscalar_layout.cc
@@ -15,7 +15,7 @@
 
 #include "qdp.h"
 #include "qdp_util.h"
-
+#include "qdp_pool_allocator.h"
 #include "qmp.h"
 
 
@@ -33,6 +33,7 @@ namespace QDP
     return s;
   }
 
+  size_t pool_size_in_gb = 8;
 
 //-----------------------------------------------------------------------------
   namespace Layout
@@ -363,6 +364,9 @@ namespace QDP
 	  QDP_error_exit("Layout::create - Layout problems, the layout functions do not work correctly with this lattice size");
       }
 #endif
+
+      Allocator::theQDPPoolAllocator::Instance().init(pool_size_in_gb);
+
       // Initialize various defaults
       initDefaults();
 

--- a/lib/qdp_pool_allocator.cc
+++ b/lib/qdp_pool_allocator.cc
@@ -1,0 +1,133 @@
+/*! @file
+ * @brief QCDOC memory allocator
+ */
+
+#include "qdp.h"
+#include "qdp_config.h"
+#include "qdp_default_allocator.h"
+#include "qdp_pool_allocator.h"
+#include <vector>
+#include <map>
+#include <new>
+#include <cstdio>
+
+
+#undef DEBUG_POOL_ALLOCATOR
+
+namespace QDP {
+namespace Allocator {
+
+	struct MemInfo
+	{
+		size_t Size;
+		unsigned char* Unaligned;
+	};
+
+	std::map<void *, MemInfo > theAllocMap;
+
+
+	QDPPoolAllocator::QDPPoolAllocator() : _PoolSize(0),
+			_MyMem(nullptr), _LargePool(nullptr){}
+
+
+	QDPPoolAllocator::~QDPPoolAllocator() {
+		if ( _LargePool ) delete _LargePool;
+		if ( _MyMem ) {
+			delete [] _MyMem;
+		}
+		_LargePool = nullptr;
+		_MyMem = nullptr;
+		_PoolSize = 0;
+	}
+
+	void
+	QDPPoolAllocator::init(size_t PoolSizeInGB)
+	{
+
+		QDPIO::cout << "Initializing TBB Pool Allocator" << std::endl;
+		if( _MyMem != nullptr ) {
+			QDPIO::cout << "Allocator Already Inited. Aborting" << std::endl;
+			QDP_abort(1);
+		}
+		theAllocMap.clear();
+
+		QDPIO::cout << std::flush;
+		_PoolSize = PoolSizeInGB*1024*1024*1024;
+
+		QDPIO::cout << "Allocating " << PoolSizeInGB << " GB"  << std::endl;
+
+		_MyMem = new (std::nothrow) unsigned char [ _PoolSize ];
+		if ( _MyMem == nullptr) {
+			QDPIO::cout << "Unable to allocate " << _PoolSize <<" bytes" << std::endl;
+			QDPIO::cout << "Aborting" <<std::endl;
+			QDP_abort(1);
+		}
+
+		_LargePool = new (std::nothrow ) tbb::fixed_pool((void *)_MyMem, _PoolSize);
+		if ( _LargePool == nullptr) {
+				QDPIO::cout << "Unable to allocate fixed pool" << std::endl;
+				QDPIO::cout << "Aborting" <<std::endl;
+				QDP_abort(1);
+		}
+	}
+
+	void*
+	QDPPoolAllocator::alloc(size_t Size)
+	{
+	    size_t BytesToAlloc;
+	    BytesToAlloc = Size;
+	    BytesToAlloc += QDP_ALIGNMENT_SIZE;
+
+
+	    unsigned char* Unaligned = (unsigned char *)(_LargePool->malloc(BytesToAlloc));
+
+	    unsigned char* Aligned = (unsigned char *)
+	    				( ( (unsigned long)Unaligned + (QDP_ALIGNMENT_SIZE-1) ) & ~(QDP_ALIGNMENT_SIZE - 1));
+
+#ifdef DEBUG_POOL_ALLOCATOR
+	    QDPIO::cout << " Allocated: " << BytesToAlloc << " Bytes, Unaligend=" <<(unsigned long) Unaligned
+	    			<< " Aligned=" << (unsigned long) Aligned << std::endl;
+#endif
+	    // Insert into the map
+	    auto r = theAllocMap.insert(std::make_pair(Aligned, MemInfo{BytesToAlloc,Unaligned}));
+
+	    // Check success of insertion.
+	    if( ! r.second ) {
+	      //QDPIO::cerr << "Failed to insert (unaligned,aligned) pair into map" << std::endl;
+	      QDP_abort(1);
+	    }
+
+	    // Return the aligned pointer
+	    return (void *)Aligned;
+	  }
+
+	void QDPPoolAllocator::free(void *mem)
+	{
+		try {
+			// Look it up.
+			auto d = theAllocMap[(unsigned char *)mem];
+#ifdef DEBUG_POOL_ALLOCATOR
+			QDPIO::cout << "PoolAlloc::free: Descriptor Found: Size="<< d.Size
+						<< "  Unaligned =" << std::hex <<(unsigned long)d.Unaligned << std::endl;
+#endif
+
+			_LargePool->free(d.Unaligned);
+
+#ifdef DEBUG_POOL_ALLOCATOR
+			QDPIO::cout << "PoolAlloc::free: Erasing Addr from theAllocMap... ";
+#endif
+
+			// Delete _InUseMap entry
+			theAllocMap.erase((unsigned char *)mem);
+
+#ifdef DEBUG_POOL_ALLOCATOR
+			QDPIO::cout << " ... done" <<std::endl;
+#endif
+		}
+		catch(...) {
+			//QDPIO::cout << "QDPPoolAllocate::free threw exception" << std::endl;
+			QDP_abort(1);
+		}
+	}
+} // namespace Allocator
+} // namespace QDP


### PR DESCRIPTION
Hi Frank, 
 Here is my modification of the qdp-jit/LLVM for KNL, basically one can enable the threaded building blocks (TBB) pool allocator with a configure option (--enable-tbb-pool-allocator)
In this case one needs to also add Flags to CXXFLAGS and LDFLAGS / LIBS to locate the include and link directories for TBB. I've also added a -poolsize <X> option where <X> is the pool size in GB. (not quite the same as you had before, e.g. -poolsize 32g won't work, just -poolsize 32).
One can specify fractional GB in the poolsize stil tho (e.g. -poolsize 0.5) for smaller pools when one is running lots of MPI nodes. If the TBB is not enabled, the original default pool is used as currently.

Nothing else should be affected.

It would be good if you could merge the changes, so that my fork is in sync with yours.
Best, 
 B