### PR TITLE
Compiles with LLVM-3.5.2 and t_mesplq passes

### DIFF
--- a/include/qdp_llvm.h
+++ b/include/qdp_llvm.h
@@ -17,11 +17,11 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Support/ToolOutputFile.h"
-#include "llvm/ADT/OwningPtr.h"
+// #include "llvm/ADT/OwningPtr.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Assembly/Parser.h"
+#include "llvm/AsmParser/Parser.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -36,11 +36,9 @@
 #include "llvm/Support/DataStream.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Program.h"
-#include "llvm/Support/system_error.h"
 #include "llvm/Support/MemoryBuffer.h"
 
-#include "llvm/Linker.h"
-#include "llvm/Assembly/PrintModulePass.h"
+#include "llvm/Linker/Linker.h"
 
 #include "llvm/ExecutionEngine/ObjectBuffer.h"
 #include "llvm/IR/GlobalVariable.h"


### PR DESCRIPTION
HI Frank, 
 I hacked this for LLVM-3.5.2 and submit for your review. QDP-JIT passed with it, and I could run t_mesplq. The major thing appeared to be that DataLayout() is no longer a pass, OwningPtr was deprecated for std::unique_ptr, and a couple of headers got moved around. I am now going to see if I can build it with LLVM-3.7.0

Since I mucked with the data layout, you should really check I haven't messed up anything. I used some GitHub code as an example but I lost the window to put this pull request. I'll find it and comment.