### PR TITLE
Configure fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -406,7 +406,7 @@ fi
 
 AC_MSG_NOTICE([Found LLVM configuration program ${LLVM_CONFIG}])
 #AC_SUBST(LLVM_CXXFLAGS, "`${LLVM_CONFIG} --cxxflags| sed -e 's/-fno-exceptions//'| sed -e 's/-fno-rtti//'| sed -e 's/-fvisibility-inlines-hidden//'| sed -e 's/-fPIC//'| sed -e 's/-Woverloaded-virtual//'| sed -e 's/-Wcast-qual//'   `")
-AC_SUBST(LLVM_CXXFLAGS, "`${LLVM_CONFIG} --cxxflags| sed -e 's/-g//'| sed -e 's/-fno-exceptions//'| sed -e 's/-std=c++11//'`")
+AC_SUBST(LLVM_CXXFLAGS, "`${LLVM_CONFIG} --cxxflags| sed -e 's/-fno-exceptions//'| sed -e 's/-std=c++11//'`")
 AC_MSG_NOTICE([LLVM compile flags: ${LLVM_CXXFLAGS}])
 AC_SUBST(LLVM_LDFLAGS,  "`${LLVM_CONFIG} --ldflags`")
 AC_MSG_NOTICE([LLVM linking flags: ${LLVM_LDFLAGS}])


### PR DESCRIPTION
*) Updated xpath_reader  (where I removed a lot of extra ;-s from the end of namespace scope blocks that made the compilation very loud)
*) Changed the sed in configure.ac so that it doesn't eat '-g' (this caused issues for me with pathnames containing -g).