### PR TITLE
Llvm nvptx llvm5.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -389,7 +389,14 @@ AC_ARG_WITH(llvm,
   [LLVM_HOME="$with_llvm"]
 )
 
-
+AC_ARG_ENABLE(llvm6-trunk,
+  AC_HELP_STRING(
+    [--enable-llvm6-trunk],
+    [Enable changes to compile with LLVM6 Trunk]
+  ),
+  [LLVM6_ENABLED=$enableval],
+  [LLVM6_ENABLED="no"]
+)
 
 if test "X${LLVM_HOME}X" = "XX" ; then
   AC_PATH_PROG(LLVM_CONFIG, [llvm-config], [])
@@ -401,7 +408,10 @@ if test "X${LLVM_CONFIG}X" = "XX" ; then
   AC_MSG_ERROR([LLVM configuration program llvm-config not found.])
 fi
 
-
+if test "X${LLVM6_ENABLED}X" = "XyesX"; then
+  AC_MSG_NOTICE([Enabling changes for LLVM6 ])
+  AC_DEFINE(QDP_LLVM6_TRUNK, [1], [ Compile for LLVM6  ])
+fi
 
 
 AC_MSG_NOTICE([Found LLVM configuration program ${LLVM_CONFIG}])

--- a/configure.ac
+++ b/configure.ac
@@ -394,7 +394,7 @@ AC_ARG_ENABLE(llvm6-trunk,
     [--enable-llvm6-trunk],
     [Enable changes to compile with LLVM6 Trunk]
   ),
-  [LLVM6_ENABLED=$enableval],
+  [LLVM6_ENABLED=${enableval}],
   [LLVM6_ENABLED="no"]
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,19 @@ AC_ARG_ENABLE(filedb,
   [filedb_enabled="yes"]
 )
 
+dnl comm-split to find device id
+AC_ARG_ENABLE(comm-split-deviceinit,
+  AC_HELP_STRING([--enable-comm-split-deviceinit],
+     [Select Device by identifying Node Local Ranks using MPI_Comm_split ]),
+  [qdp_comm_split_init_enabled="${enableval}"],
+  [qdp_comm_split_init_enabled="no"]
+)
+
+if test "X${qdp_comm_split_init_enabled}X" == "XyesX";
+then
+ AC_MSG_NOTICE([Local Rank identification with MPI_Comm_split])
+ AC_DEFINE([QDP_USE_COMM_SPLIT_INIT], [1],[Comm split for local ranks])
+fi
 
 dnl if test "X${gpu_enabled}X" == "XyesX"; 
 dnl then
@@ -173,15 +186,6 @@ then
      AC_SUBST(GPU_DEBUGDEEP_CXX,"-DGPU_DEBUG_DEEP")
 fi
 
-dnl if QCDOC is enabled change some settings
-if test ${ac_qcdoc_enabled} -eq 1; then 
-   AC_DEFINE_UNQUOTED(QDP_USE_QCDOC, ${ac_qcdoc_enabled}, [Enable QCDOC opts])
-fi
-
-dnl if QCDOC is enabled change some settings
-if test ${ac_bgl_enabled} -eq 1; then 
-   AC_DEFINE_UNQUOTED(QDP_USE_BLUEGENEL, ${ac_bgl_enabled}, [Enable BGL opts])
-fi
 
 dnl Check if profiling is enabled
 if test ${ac_profile} -eq 1; then 

--- a/include/qdp_init.h
+++ b/include/qdp_init.h
@@ -3,13 +3,16 @@
 #ifndef QDP_INIT
 #define QDP_INIT
 
+#ifndef QDP_CONFIG_H
+#include "qdp_config.h"
+#endif
+
 /*! \file
  * \brief Routines for top level QDP management
  *
  * Fundamental routines for turning on/off and inserting/extracting
  * variables.
  */
-
 
 // Info/error routines
 namespace QDP {
@@ -18,6 +21,9 @@ namespace QDP {
   extern bool QDPuseGPU;
   extern bool setPoolSize;
   int QDP_setGPU(); // returns the CUDA device number that was actually set
+#ifdef QDP_USE_COMM_SPLIT_INIT
+  int QDP_setGPUCommSplit();
+#endif
   void QDP_startGPU();
 #endif
 

--- a/include/qdp_llvm.h
+++ b/include/qdp_llvm.h
@@ -1,11 +1,10 @@
 #ifndef QDP_LLVM
 #define QDP_LLVM
 
+#include "qdp_config.h"
+
 //#define __STDC_LIMIT_MACROS
 //#define __STDC_CONSTANT_MACROS
-#ifndef LLVM_TRUNK
-#define LLVM_TRUNK
-#endif
 
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/IR/Module.h"
@@ -27,11 +26,13 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetMachine.h"
-#ifdef LLVM_TRUNK
+
+#ifdef QDP_LLVM6_TRUNK
 #include "llvm/CodeGen/TargetLowering.h"
 #else
 #include "llvm/Target/TargetLowering.h"
 #endif
+
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Support/ToolOutputFile.h"

--- a/include/qdp_llvm.h
+++ b/include/qdp_llvm.h
@@ -3,6 +3,9 @@
 
 //#define __STDC_LIMIT_MACROS
 //#define __STDC_CONSTANT_MACROS
+#ifndef LLVM_TRUNK
+#define LLVM_TRUNK
+#endif
 
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/IR/Module.h"
@@ -24,7 +27,11 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetMachine.h"
+#ifdef LLVM_TRUNK
+#include "llvm/CodeGen/TargetLowering.h"
+#else
 #include "llvm/Target/TargetLowering.h"
+#endif
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Support/ToolOutputFile.h"
@@ -66,7 +73,7 @@
 #include "llvm/IR/AssemblyAnnotationWriter.h"
 
 namespace llvm {
-ModulePass *createNVVMReflectPass(const StringMap<int>&);
+ModulePass *createNVVMReflectPass(void);
 }
 
 

--- a/lib/qdp_llvm.cc
+++ b/lib/qdp_llvm.cc
@@ -2,7 +2,7 @@
 
 #include "qdp_libdevice.h"
 //#include "nvvm.h"
-
+#include "llvm/InitializePasses.h"
 #include "llvm/IR/DataLayout.h"
 //#include "llvm/Bitcode/ReaderWriter.h"
 #include "llvm/Support/FileSystem.h"
@@ -427,7 +427,7 @@ namespace QDP {
     llvm::initializeCodeGen(*Registry);
     llvm::initializeLoopStrengthReducePass(*Registry);
     llvm::initializeLowerIntrinsicsPass(*Registry);
-    llvm::initializeCountingFunctionInserterPass(*Registry);
+//    llvm::initializeCountingFunctionInserterPass(*Registry);
     llvm::initializeUnreachableBlockElimLegacyPassPass(*Registry);
     llvm::initializeConstantHoistingLegacyPassPass(*Registry);
 
@@ -984,8 +984,8 @@ namespace QDP {
 
     llvm::Constant *Bar = Mod->getOrInsertFunction( "llvm.nvvm.barrier0" , 
 						    IntrinFnTy , 
-						    llvm::AttributeSet::get(TheContext, 
-									    llvm::AttributeSet::FunctionIndex, 
+						    llvm::AttributeList::get(TheContext, 
+									    llvm::AttributeList::FunctionIndex, 
 									    ABuilder)
 						    );
 
@@ -1005,8 +1005,8 @@ namespace QDP {
 
     llvm::Constant *ReadTidX = Mod->getOrInsertFunction( name , 
 							 IntrinFnTy , 
-							 llvm::AttributeSet::get(TheContext, 
-										 llvm::AttributeSet::FunctionIndex, 
+							 llvm::AttributeList::get(TheContext, 
+										 llvm::AttributeList::FunctionIndex, 
 										 ABuilder)
 							 );
 
@@ -1111,7 +1111,7 @@ namespace QDP {
     if (DisableInline) {
       // No inlining pass
     } else if (OptLevel > 1) {
-      Builder.Inliner = createFunctionInliningPass(OptLevel, SizeLevel);
+      Builder.Inliner = createFunctionInliningPass(OptLevel, SizeLevel, false);
     } else {
       Builder.Inliner = createAlwaysInlinerLegacyPass();
     }
@@ -1128,12 +1128,16 @@ namespace QDP {
     Builder.SLPVectorize = DisableSLPVectorization ? false : OptLevel > 1 && SizeLevel < 2;
 
     // Add target-specific passes that need to run as early as possible.
+#if 0
     if (TM)
       Builder.addExtension(
 			   llvm::PassManagerBuilder::EP_EarlyAsPossible,
-			   [&](const llvm::PassManagerBuilder &, llvm::legacy::PassManagerBase &PM) {
-			     TM->addEarlyAsPossiblePasses(PM);
+			   [&](llvm::PassManagerBuilder &PMB, llvm::legacy::PassManagerBase &PM) {
+			     TM->adjustPassManager(PMB);
 			   });
+#else
+   if( TM ) TM->adjustPassManager(Builder);
+#endif
 
     Builder.populateFunctionPassManager(FPM);
     Builder.populateModulePassManager(MPM);
@@ -1223,8 +1227,8 @@ namespace QDP {
 										       "",
 										       llvm::TargetOptions(),
 										       getRelocModel(),
-										       llvm::CodeModel::Default,
-										       llvm::CodeGenOpt::Aggressive ));
+										       None,
+										       llvm::CodeGenOpt::Aggressive, true ));
 
     assert(target_machine.get() && "Could not allocate target machine!");
 
@@ -1362,7 +1366,7 @@ namespace QDP {
 
     llvm::legacy::PassManager OurPM;
     OurPM.add( llvm::createInternalizePass( all_but_main ) );
-    OurPM.add( llvm::createNVVMReflectPass(Mapping));
+    OurPM.add( llvm::createNVVMReflectPass());
     OurPM.run( *Mod );
 
 

--- a/lib/qdp_llvm.cc
+++ b/lib/qdp_llvm.cc
@@ -1,4 +1,5 @@
 #include "qdp.h"
+#include "qdp_config.h"
 
 #include "qdp_libdevice.h"
 //#include "nvvm.h"
@@ -1220,7 +1221,8 @@ namespace QDP {
     std::string compute = oss.str();
 
     //QDPIO::cout << "create target machine for compute capability " << compute << "\n";
-    
+   
+#ifdef QDP_LLVM6_TRUNK 
     std::unique_ptr<llvm::TargetMachine> target_machine(TheTarget->createTargetMachine(
 										       "nvptx64-nvidia-cuda",
 										       compute,
@@ -1229,6 +1231,25 @@ namespace QDP {
 										       getRelocModel(),
 										       None,
 										       llvm::CodeGenOpt::Aggressive, true ));
+#else
+    std::unique_ptr<llvm::TargetMachine> target_machine(TheTarget->createTargetMachine(
+
+       "nvptx64-nvidia-cuda",
+
+       compute,
+
+       "",
+
+       llvm::TargetOptions(),
+
+       getRelocModel(),
+
+       llvm::CodeModel::Default,
+
+       llvm::CodeGenOpt::Aggressive));
+
+
+#endif
 
     assert(target_machine.get() && "Could not allocate target machine!");
 


### PR DESCRIPTION
Hi Frank, 
 Here are my mods for getting us running on Summit. The code should work with LLVM-5.0 and with the version of trunk I use, if we give the --enable-llvm6-trunk configure argument (which I have been doing). Nearly all of my current testing has been with LLVM6-trunk. The build validated on SummitDev using actual configurations and a short trajectory when used with the latest chroma-devel notwithstanding the general Chroma regression testing issues we discussed last week, which is great! 
 
 Another issue I've addressed here, is that unfortunately IBM Spectrum MPI, although based on OpenMPI, does not give us the OMPI_COMM_WORLD_LOCAL_RANK environment variable which we use for startup.   I looked for a way to do this portably and MPI-3 allows it using MPI_Comm_split_type() which allows MPI_COMM_WORLD to be split into several subcommunicators where each subcommunicator corresponds to a region where shared memory is possible which is as close as possible to 'a node'. Each MPI process then gets its rank from its subcommunicator, to determine its node-local rank.  However, this requires that MPI has inited.  To enable this, on needs to add --enable-comm-split-deviceinit  at compile time. As more MPI implementations support this MPI-3.0 feature, we can perhaps switch to this wholeheartedly. Chroma's initialization will then also work appropriately (added to chroma devel)

