### PR TITLE
Updated patch_libdevice.sh 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,9 +20,22 @@ AC_ARG_WITH(cuda,
   [ cuda_home="${withval}" ],
   [ cuda_home="/usr/local/cuda" ]
 )
+
+AC_ARG_ENABLE(cuda-managed-memory,
+   AC_HELP_STRING([--enable-cuda-managed-memory], [ Enable memory to be allocated with Cuda Managed Memory ] ),
+   [ cuda_managed_memory="${enableval}" ],
+   [ cuda_managed_memory="no" ]
+)
+
 AC_MSG_NOTICE([Configuring with CUDA installed in = ${cuda_home}])
 AC_DEFINE_UNQUOTED(CUDA_DIR,"${cuda_home}",[CUDA install path])
 AC_SUBST(SUBST_CUDA_DIR,"${cuda_home}")
+
+if test "X${cuda_managed_memory}X" == "XyesX";
+then
+  AC_MSG_NOTICE([Will Use CUDA Managed Memory for Allocations])
+  AC_DEFINE(QDP_USE_CUDA_MANAGED_MEMORY, [1], [ CUDA use managed memory ])
+fi
 
 
 dnl

--- a/lib/qdp_cuda.cc
+++ b/lib/qdp_cuda.cc
@@ -492,11 +492,22 @@ namespace QDP {
   bool CudaMalloc(void **mem , size_t size )
   {
     CUresult ret;
+#ifndef QDP_USE_CUDA_MANAGED_MEMORY
     ret = cuMemAlloc( (CUdeviceptr*)mem,size);
+#else
+    ret = cuMemAllocManaged( (CUdeviceptr*)mem, size, CU_MEM_ATTACH_GLOBAL ); 
+#endif
+
 #ifdef GPU_DEBUG_DEEP
     QDP_debug_deep( "CudaMalloc %p", *mem );
 #endif
+
+#ifndef  QDP_USE_CUDA_MANAGED_MEMORY
     CudaRes("cuMemAlloc",ret);
+#else 
+    CudaRes("cuMemAllocManaged", ret);
+#endif
+
     return ret == CUDA_SUCCESS;
   }
 

--- a/patch_libdevice.sh
+++ b/patch_libdevice.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
-if [ "$#" -ne 1 ] || ! [ -d "$1" ]; then
-  echo "Usage: $0 DIRECTORY" >&2
+if [ "$#" -ne 2 ] || ! [ -d "$1" ] || ! [ -d "$2" ]; then
+  echo "Usage: $0 libdevice_dir llvm_dir" >&2
   exit 1
 fi
 
-LLVMAS=/home/fwinter/toolchain/install/llvm-4.0.1/bin/llvm-as
-LLVMDIS=/home/fwinter/toolchain/install/llvm-4.0.1/bin/llvm-dis
+LLVMAS=$2/bin/llvm-as
+LLVMDIS=$2/bin/llvm-dis
+
+if ! [ -x $LLVMAS ] || ! [ -x ${LLVMDIS} ]; then
+   echo "either one of $LLVMAS or $LLVMDIS is not executable" >& 2
+   exit 1
+fi
 
 LIBDEVICE_DIR=$1
 


### PR DESCRIPTION
Updated this patcher so that I can give  location of an LLVM installation, to allow for
easier scriptable building on Titan. So instead of  
```
$ ./patch_libdevice.sh <libnvvm-libdevice-dir>
```
the new usage is 
```
$ ./patch_libdevice.sh <libnvvm-libdevice-dir> <llvm-install-dir>
```
The new script checks that 
```<llvm-install-dir>/bin/llvm-dis``` and ```<llvm-install-dir>/bin/llvm-as``` exist and are executable