### PR TITLE
Llvm cpu inner loop no11 qshift

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,6 @@ dnl --with-xxxx and --enable-xxxx switches
 dnl
 
 
-
 dnl --enable-Nd
 AC_ARG_ENABLE(Nd,
   AC_HELP_STRING([--enable-Nd=N ],
@@ -279,6 +278,19 @@ AC_ARG_WITH(llvm,
   [LLVM_HOME="$with_llvm"]
 )
 
+AC_ARG_ENABLE(llvm6-trunk,
+  AC_HELP_STRING(
+    [--enable-llvm6-trunk],
+    [Enable changes to compile with LLVM6 Trunk]
+  ),
+  [LLVM6_ENABLED=${enableval}],
+  [LLVM6_ENABLED="no"]
+)
+
+if test "X${LLVM6_ENABLED}X" = "XyesX"; then
+  AC_MSG_NOTICE([Enabling changes for LLVM6 ])
+  AC_DEFINE(QDP_LLVM6_TRUNK, [1], [ Compile for LLVM6  ])
+fi
 
 echo "X`${LLVM_HOME}/bin/llvm-config --libs`X"
 if test "X`${LLVM_HOME}/bin/llvm-config --libs`X" = "XX" ; then

--- a/include/qdp_jit.h
+++ b/include/qdp_jit.h
@@ -274,7 +274,9 @@ namespace QDP {
   jit_llvm_builtin jit_type_promote(jit_llvm_builtin t0,jit_llvm_builtin t1);
   jit_llvm_type    jit_type_promote(jit_llvm_type t0   ,jit_llvm_type t1);
 
+#if 0
   void llvm_bar_sync( int a );
+#endif
 
   llvm::Value * llvm_add_param( jit_llvm_type type );
   llvm::Value * llvm_alloca( jit_llvm_builtin type , int count );

--- a/include/qdp_llvm.h
+++ b/include/qdp_llvm.h
@@ -235,9 +235,9 @@ namespace QDP {
 
   llvm::Value * llvm_alloca( llvm::Type* type , int elements );
   //  llvm::Value * llvm_get_shared_ptr( llvm::Type *ty );
-
+#if 0
   void llvm_bar_sync();
-
+#endif
   void addKernelMetadata(llvm::Function *F);
 
 

--- a/include/qdp_llvm.h
+++ b/include/qdp_llvm.h
@@ -1,6 +1,7 @@
 #ifndef QDP_LLVM
 #define QDP_LLVM
 
+#include "qdp_config.h"
 //#define __STDC_LIMIT_MACROS
 //#define __STDC_CONSTANT_MACROS
 
@@ -25,7 +26,13 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetMachine.h"
+
+#ifdef QDP_LLVM6_TRUNK
+#include "llvm/CodeGen/TargetLowering.h"
+#else
 #include "llvm/Target/TargetLowering.h"
+#endif
+
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Support/ToolOutputFile.h"
@@ -224,8 +231,9 @@ namespace QDP {
   void          llvm_store_ptr_idx( llvm::Value * val , llvm::Value * ptr , llvm::Value * idx );
 
   llvm::Value * llvm_array_type_indirection( ParamRef p , llvm::Value* idx );
-
+#if 0
   llvm::Value * llvm_special( const char * name );
+#endif
 
   //  llvm::Value * llvm_omp_get_num_threads();
 

--- a/lib/qdp_llvm.cc
+++ b/lib/qdp_llvm.cc
@@ -943,7 +943,7 @@ namespace QDP {
   }
 
 
-
+#if 0
   void llvm_bar_sync()
   {
     llvm::FunctionType *IntrinFnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(TheContext), false);
@@ -960,7 +960,7 @@ namespace QDP {
 
     builder->CreateCall(Bar);
   }
-
+#endif
 
   
 

--- a/lib/qdp_llvm.cc
+++ b/lib/qdp_llvm.cc
@@ -1,6 +1,9 @@
 #include "qdp.h"
 
 
+#include "llvm/Support/FileSystem.h"
+//#include "llvm/Support/MemoryBuffer.h"
+
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm-c/Core.h"
@@ -469,7 +472,11 @@ namespace QDP {
 	  B.addAlignmentAttr( QDP_ALIGNMENT_SIZE );
 	}
 
+#if 0
       	AI->addAttr( llvm::AttributeSet::get( TheContext , 0 ,  B ) );
+#else
+	  AI->addAttrs(  B  );
+#endif
       }
 
       vecArgument.push_back( &*AI );
@@ -964,7 +971,7 @@ namespace QDP {
 
   
 
-
+#if 0
   llvm::Value * llvm_special( const char * name )
   {
     llvm::FunctionType *IntrinFnTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(TheContext), false);
@@ -982,7 +989,7 @@ namespace QDP {
     return builder->CreateCall(ReadTidX);
   }
 
-
+#endif
 
   // llvm::Value * llvm_call_special_tidx() { return llvm_special("llvm.nvvm.read.ptx.sreg.tid.x"); }
   // llvm::Value * llvm_call_special_ntidx() { return llvm_special("llvm.nvvm.read.ptx.sreg.ntid.x"); }


### PR DESCRIPTION
Hi Frank, 
 I had a go today at bringing the CPU version of QDP-JIT up to the same revision of LLVM as the GPU NVPTX version. This pull is the result. Code compiles with LLVM-5.0.0 and if one adds --enable-llvm6-trunk it will compile with LLVM6 trunk with the following revision:

```commit dbbb6c5fc3642987430866dffdf710df4f616ac7
Author: Nirav Dave <niravd@google.com>
Date:   Mon Nov 27 15:28:15 2017 +0000

    [DAG] Do MergeConsecutiveStores again before Instruction Selection
    
    Summary:
    
    Now that store-merge is only generates type-safe stores, do a second
    pass just before instruction selection to allow lowered intrinsics to
    be merged as well.
    
    Reviewers: jyknight, hfinkel, RKSimon, efriedma, rnk, jmolloy
    
    Subscribers: javed.absar, llvm-commits
    
    Differential Revision: https://reviews.llvm.org/D33675
    
    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@319036 91177308-0d34-0410-b5e6-96231b3b80d8
```

I guess for more recent versions of LLVM6-trunk we may need further updates, but at least this is now consistent between my CPU and GPU builds. I think the only major change I came accross was a header file, some special functions 

```llvm_special```
and
```llvm_bar_sync```
which both seemed to be code for NVPTX. There was one header file addition for an I/O flag and an addAttr call got changed to addAttrs() which now takes an AttributeBuilder, so it looked like I can just hand it the AttributeBuilder without needing to to a get(context,0,B).

If you approve, please feel free to merge at your leisure.
Thanks and best wishes, 
 B