### PR TITLE
Llvm nvptx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "other_libs/xpath_reader"]
 	path = other_libs/xpath_reader
-	url = https://github.com/usqcd-software/xpath_reader.git
+	url = ../xpath_reader.git
 [submodule "other_libs/qio"]
 	path = other_libs/qio
-	url = https://github.com/usqcd-software/qio.git
+	url = ../qio.git
 [submodule "other_libs/filedb"]
 	path = other_libs/filedb
-	url = https://github.com/usqcd-software/filedb.git
+	url = ../filedb.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "other_libs/xpath_reader"]
 	path = other_libs/xpath_reader
-	url = https://github.com/usqcd-software/xpath_reader.git
+	url = ../../usqcd-software/xpath_reader.git
 [submodule "other_libs/qio"]
 	path = other_libs/qio
-	url = https://github.com/usqcd-software/qio.git
+	url = ../../usqcd-software/qio.git
 [submodule "other_libs/filedb"]
 	path = other_libs/filedb
-	url = https://github.com/usqcd-software/filedb.git
+	url = ../../usqcd-software/filedb.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "other_libs/xpath_reader"]
 	path = other_libs/xpath_reader
-	url = ../xpath_reader.git
+	url = https://github.com/usqcd-software/xpath_reader.git
 [submodule "other_libs/qio"]
 	path = other_libs/qio
-	url = ../qio.git
+	url = https://github.com/usqcd-software/qio.git
 [submodule "other_libs/filedb"]
 	path = other_libs/filedb
-	url = ../filedb.git
+	url = https://github.com/usqcd-software/filedb.git

--- a/COPYING
+++ b/COPYING
@@ -1,37 +1,19 @@
-		            COPYRIGHT AND LICENSE
+LICENSE:
+========
 
-Copyright (c) 1995,1996   Southeastern Universities Research Association
-		          Continuous Electron Beam Accelerator Facility
-			  Thomas Jefferson National Accelerator Facility
-			  12000 Jefferson Avenue, Newport News, VA 23606 
+Jefferson Science Associates LLC Copyright Notice:
 
-This material resulted from work developed under a United States Government 
-Contract and is subject to the following license:
+Copyright © 2018 Jefferson Science Associates LLC All Rights Reserved.
 
-The Government retains a paid-up, nonexclusive, irrevocable worldwide license
-to reproduce, prepare derivative works, perform publicly and display publicly
-by or for the Government including the right to distribute to other Government
-contractors. 
+Redistribution and use in source and binary forms, with or without modification, are permitted as a licensed user provided that the following conditions are met:
 
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
-                  DISCLAIMER AND LIMITATION OF WARRANTY.                    
-                                                                            
-         ALL SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY. THERE           
-         ARE NO WARRANTIES EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED        
-         WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR            
-         PURPOSE. THERE IS NO WARRANTY THAT USE WILL NOT INFRINGE           
-         ANY PATENT, COPYRIGHT OR TRADEMARK.                                
-                                                                            
-In consideration of the use of the software and other materials, user agrees
-that neither the Government nor SURA/TJNAF will be liable for any damages with 
-respect to such use, and user shall hold both the Government and SURA/TJNAF
-harmless from and indemnify them against any and all liability for damages
-arising out of the use of such software and other materials. In no event shall
-the Government or SURA/TJNAF be liable whether arising under contract, tort,
-strict liability or otherwise for any incidental, indirect or consequential 
-loss or damage of any nature arising at any time from any cause whatsoever. In
-addition, the Government and SURA/TJNAF assume no obligation for defending
-against third party claims or threats of claims arising as a result of user's
-use of the software or materials either as delivered to user or as modified by
-user.  
-                                                                            
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission.
+
+This material resulted from work developed under a United States Government
+Contract.  The Government retains a paid-up, nonexclusive, irrevocable worldwide license in such copyrighted data to reproduce, distribute copies to the public, prepare derivative works, perform publicly and display publicly and to permit others to do so.  
+THIS SOFTWARE IS PROVIDED BY JEFFERSON SCIENCE ASSOCIATES LLC "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL JEFFRSON SCIENCE ASSOCIATES, LLC OR THE U.S. GOVERNMENT BE LIABLE TO LICENSEE OR ANY THIRD PARTES FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+LICENSE:
+========
+
+Jefferson Science Associates LLC Copyright Notice:
+
+Copyright © 2018 Jefferson Science Associates LLC All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted as a licensed user provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission.
+
+This material resulted from work developed under a United States Government
+Contract.  The Government retains a paid-up, nonexclusive, irrevocable worldwide license in such copyrighted data to reproduce, distribute copies to the public, prepare derivative works, perform publicly and display publicly and to permit others to do so.  
+THIS SOFTWARE IS PROVIDED BY JEFFERSON SCIENCE ASSOCIATES LLC "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL JEFFRSON SCIENCE ASSOCIATES, LLC OR THE U.S. GOVERNMENT BE LIABLE TO LICENSEE OR ANY THIRD PARTES FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/lib/qdp_cuda.cc
+++ b/lib/qdp_cuda.cc
@@ -27,8 +27,6 @@ namespace QDP {
   CUdevice cuDevice;
   CUcontext cuContext;
 
-
-
   std::map<CUresult,std::string> mapCuErrorString= {
     {CUDA_SUCCESS,"CUDA_SUCCESS"},
     {CUDA_ERROR_INVALID_VALUE,"CUDA_ERROR_INVALID_VALUE"},
@@ -225,8 +223,10 @@ namespace QDP {
 
   void CudaGetSM(int* maj,int* min) {
     CUresult ret;
-    ret = cuDeviceComputeCapability( maj , min , cuDevice );
-    CudaRes("cuDeviceComputeCapability",ret);
+    ret = cuDeviceGetAttribute(maj, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, cuDevice );
+    CudaRes("cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR)",ret);
+    ret = cuDeviceGetAttribute(min, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, cuDevice );
+    CudaRes("cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR)",ret);
   }
 
   void CudaInit() {
@@ -284,11 +284,17 @@ namespace QDP {
 
     QDP_info_primary("trying to get device %d",dev);
     ret = cuDeviceGet(&cuDevice, dev);
-    CudaRes("",ret);
+    CudaRes(__func__,ret);
 
-    QDP_info_primary("trying to create a context");
-    ret = cuCtxCreate(&cuContext, CU_CTX_MAP_HOST, cuDevice);
-    CudaRes("",ret);
+    QDP_info_primary("trying to grab pre-existing context",dev);
+    ret = cuCtxGetCurrent(&cuContext);
+    
+    if (ret != CUDA_SUCCESS) {
+      QDP_info_primary("trying to create a context");
+      ret = cuCtxCreate(&cuContext, CU_CTX_MAP_HOST, cuDevice);
+    }
+    CudaRes(__func__,ret);
+
   }
 
 


### PR DESCRIPTION
Hi Frank, I have a very few patches here for you: 
  - changed .gitmodules to be transport agnostic (using a relative URL) this means if you check out the toplevel submodule by SSH the submodules will also be checked out with SSH, whereas if you check out via HTTPS, the submodules will also come via HTTPS. I have implemented this in Chroma and QDPXX as well
  - Kate had a patch for context initialization in qdp_cuda.cc so that before creating the context qdp-jit will check if there is already one and use that. Apparently this is needed on some newer Cray systems like PizDaint where the MPI creates a context already.
  - The API calls to get major and minor versions of the code were deprecated and I replaced them with a pair of device attribute queries that I was told were the appropriate replacements. 

Also I had to muck about with the JLab license files. 
Many thanks and best wishes, 
 Balint