### PR TITLE
Llvm nvptx

### DIFF
--- a/lib/qdp_cuda.cc
+++ b/lib/qdp_cuda.cc
@@ -289,7 +289,7 @@ namespace QDP {
     QDP_info_primary("trying to grab pre-existing context",dev);
     ret = cuCtxGetCurrent(&cuContext);
     
-    if (ret != CUDA_SUCCESS) {
+    if (ret != CUDA_SUCCESS || cuContext == NULL) {
       QDP_info_primary("trying to create a context");
       ret = cuCtxCreate(&cuContext, CU_CTX_MAP_HOST, cuDevice);
     }


### PR DESCRIPTION
Hi Frank, 
 Two slight changes. One is for how the submodules are checked out. I have changed these to relative paths, to allow transport agnostic checkout, so if you clone with SSH, submodules will be cloned with SSH. If you clone with HTTPS it should also clone with HTTPS. 
 
The second is a minor fix to the code which checks if there is already an existing context. Apparantly that can return a SUCCESS even if ther is no existing context, but just set the context to NULL. I have added the check suggested by Mathias, and check that the context is NULL. Now this seems to work both for Mathias' cases and on Piz Daint for Kate.