### PR TITLE
Updated CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,9 +330,9 @@ configure_package_config_file(QDPXXConfig.cmake.in QDPXXConfig.cmake INSTALL_DES
 # Make the version file
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    QDPXXVersion.cmake
+    QDPXXConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
     COMPATIBILITY AnyNewerVersion
     )
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QDPXXVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QDPXXConfig.cmake DESTINATION lib/cmake/QDPXX)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QDPXXConfigVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QDPXXConfig.cmake DESTINATION lib/cmake/QDPXX)


### PR DESCRIPTION
Hi Frank, 
 This is a very minor PR, it turns out that. `find_package(QDPXX "X.Y.Z")`  call to find version X.Y.Z or newer only works if we dump a QDPXXConfigVersion.cmake rather than a QDPXXVersion.cmake. This PR Just makes that change.

Best,  B