### PR TITLE
Fix for CUDA build on Summit. 

### DIFF
--- a/include/qdp_config_internal.h.cmake.in
+++ b/include/qdp_config_internal.h.cmake.in
@@ -88,6 +88,9 @@
 /* Compile for LLVM 12.0 release */
 #cmakedefine QDP_LLVM12				@QDP_LLVM12@
 
+/* Compile for LLVM 13.0 series */	
+#cmakedefine QDP_LLVM13				@QDP_LLVM13@
+
 /* Number of color components */
 #cmakedefine QDP_NC				@QDP_NC@
 

--- a/lib/qdp_llvm.cc
+++ b/lib/qdp_llvm.cc
@@ -1714,7 +1714,11 @@ namespace QDP
 	std::string module_name = "module_" + str_kernel_name + ".bc";
 	QDPIO::cout << "write code to " << module_name << "\n";
 	std::error_code EC;
+#if QDP_LLVM13
+	llvm::raw_fd_ostream OS(module_name, EC, llvm::sys::fs::OF_None);
+#else
 	llvm::raw_fd_ostream OS(module_name, EC, llvm::sys::fs::F_None);
+#endif
 	llvm::WriteBitcodeToFile(*Mod, OS);
 	OS.flush();
       }


### PR DESCRIPTION
There was a catch in the CUDA build on Summit to do with LLVM-13 (F_None->OF_None). Oddly the QDP_LLVM13 macro was not set in the qdp_config.h.cmake.in file. This is odd as I thought I used' this already once with ROCm-4.3.

In any case. It is a tiny fix.
